### PR TITLE
disable autogenerated vscode completions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.autoImportCompletions": false,
+}


### PR DESCRIPTION
A lot of team members are experiencing issues with imports that are hard to debug due to incorrect import statements that are autogenerated by VSCode. This pull request disables VSCode autogenerating import statements for python files for developers on this project.